### PR TITLE
experiment with enabling CORS for web fonts

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,5 @@
+# Workaround to address staged deploy issues with CORS
+/fonts/*
+  Access-Control-Allow-Origin: *
+/css/*
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
I get a bunch of these errors when testing a branch deploy:

<img width="1051"  src="https://user-images.githubusercontent.com/359239/59162282-7c96ee00-8ac4-11e9-80ce-d24186c6c48d.png">

I _think_ this is how to make this go away, based on https://www.netlify.com/docs/headers-and-basic-auth/