### PR TITLE
accessibility cleanup 

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,10 +12,10 @@
 {{ end }}
 
 {{ if eq .URL "/" }}
-<meta property="description" content="{{ .Site.Params.description }}">
+<meta name="description" content="{{ .Site.Params.description }}">
 {{ else }}
   {{ if .Description }}
-  <meta property="description" content="{{ .Description }}">
+  <meta name="description" content="{{ .Description }}">
   {{ end }}
 {{ end }}
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -11,10 +11,10 @@
     <li><a href="{{ .URL }}">{{ .Name }}</a></li>
     {{ end }}
     <li>
-        <a href="https://twitter.com/shiftkey"><i class="fa fa-twitter"></i></a>
-      </li>
-      <li>
-        <a href="https://github.com/shiftkey"><i class="fa fa-github"></i></a>
-      </li>
+      <a href="https://twitter.com/shiftkey" aria-label="shiftkey on Twitter"><i class="fa fa-twitter"></i></a>
+    </li>
+    <li>
+      <a href="https://github.com/shiftkey" aria-label="shiftkey on GitHub"><i class="fa fa-github"></i></a>
+    </li>
     </ul>
 </nav>

--- a/themes/hugo-natrium-theme/static/css/main.css
+++ b/themes/hugo-natrium-theme/static/css/main.css
@@ -246,7 +246,7 @@ blockquote {
   display: block;
   padding: 4px 0;
   font-family: 'Lato', sans-serif;
-  color: #ccc;
+  color: #595959;
   font-size: 14px;
 }
 
@@ -254,7 +254,7 @@ blockquote {
   display: block;
   padding: 4px 0;
   font-family: 'Lato', sans-serif;
-  color: #ccc;
+  color: #595959;
   font-size: 14px;
 }
 
@@ -355,7 +355,7 @@ blockquote {
 }
 
 .footer-links a {
-  color: #888;
+  color: #595959;
   text-decoration: none;
   transition: color 300ms;
   margin: 0 5px;
@@ -364,6 +364,16 @@ blockquote {
 .footer-links a:hover {
   color: #222;
 }
+
+
+.footer-links .fa-rss::before {
+  padding-right: 10px;
+}
+
+.footer-links .fa-github::before {
+  padding-right: 10px;
+}
+
 
 .footer-links li::before {
   content: '•';


### PR DESCRIPTION
<img width="750"  src="https://user-images.githubusercontent.com/359239/59162813-ebc51000-8acd-11e9-98d5-cdc62dc41a53.png">

This could be better:

 - [ ] tighten up contrast so text satisfies WCAG AAA
 - [ ] add `aria-label` to identified links
 - [ ] ???