### PR TITLE
use shortcodes for picture tags

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,5 +27,3 @@ pygmentsUseClasses=true
 [params]
     description = "Just a site about me and what I've been up to"
 
-[markup.goldmark.renderer]
-unsafe= true

--- a/content/notes/my-code-review-emoji-guide.md
+++ b/content/notes/my-code-review-emoji-guide.md
@@ -11,11 +11,7 @@ character to help categorize each bit of feedback.
 Here's [an example](https://github.com/desktop/desktop/pull/7635#discussion_r287833836)
 of how it looks in action:
 
-<picture>
-  <source type="image/webp" srcset="/images/review-emoji/suggested-change.webp">
-  <source type="image/png" srcset="/images/review-emoji/suggested-change.png">
-  <img src="/images/review-emoji/suggested-change.png" class="align-center" />
-</picture>
+{{< picture "/images/review-emoji/suggested-change" >}}
 
 I'll save the details and my opinions about code review itself for another post,
 as I think this guide can stand on it's own.

--- a/content/post/2016-06-26-burnout.md
+++ b/content/post/2016-06-26-burnout.md
@@ -9,11 +9,7 @@ aliases:
 On the last day of 2015 I signed off with this photo on Instagram:
 
 
-<picture>
-  <source type="image/webp" srcset="/images/on-burnout/beach.webp">
-  <source type="image/png" srcset="/images/on-burnout/beach.png">
-  <img src="/images/on-burnout/beach.png" class="align-center" />
-</picture>
+{{< picture "/images/on-burnout/beach" >}}
 
 In the attached message, I referred to the previous 12 months as a "glorious, chaotic and exhausting year". It seemed a fitting summary given all the travel and work that occurred, but it was also the easiest way for me to summarize the year without thinking about the severe case of burnout I was dealing with.
 
@@ -71,21 +67,13 @@ I meandered around several countries, used my Australian accent to open doors an
 
 You can see here where my GitHub activity fell away - the two exceptions were where I was reading the [Elm](http://elm-lang.org/) source code and committed a typo fix in some documentation, and where I started replying to notifications earlier than I should have. You can also see that I took time off last week, and stole a few days off around the Christmas-New Year break.
 
-<picture>
-  <source type="image/webp" srcset="/images/on-burnout/contributions.webp">
-  <source type="image/png" srcset="/images/on-burnout/contributions.png">
-  <img src="/images/on-burnout/contributions.png" class="align-center" />
-</picture>
+{{< picture "/images/on-burnout/contributions" >}}
 
 I came back to work in early October, and it was rather uneventful. I was able to ease my way back into a routine, and beyond the existing psychic debt I'd left behind I didn't really worry about my side projects.
 
 I was also fortunate to have friends from various corners of the globe who stayed in touch throughout this rough period. I was active on Twitter throughout this time, and sometimes they would pick up on cues and reach out. Other times, they just messaged me out of the blue to check in.
 
-<picture>
-  <source type="image/webp" srcset="/images/on-burnout/tweets.webp">
-  <source type="image/png" srcset="/images/on-burnout/tweets.png">
-  <img src="/images/on-burnout/tweets.webp" class="align-center" />
-</picture>
+{{< picture "/images/on-burnout/tweets" >}}
 
 It was cathartic to be candid about things with these people, especially when things weren't going well. I wouldn't be where I am today without their enquiries and support.
 

--- a/layouts/shortcodes/picture.html
+++ b/layouts/shortcodes/picture.html
@@ -1,0 +1,6 @@
+
+<picture>
+  <source type="image/webp" srcset="{{ .Get 0 }}.webp">
+  <source type="image/png" srcset="{{ .Get 0 }}.png">
+  <img src="{{ .Get 0 }}.png" class="align-center" />
+</picture>


### PR DESCRIPTION
I've been experimenting with using webp to render images when the browser supports it, and because it was mixing HTML with markdown it required enabling the unsafe rendering of the new Markdown renderer that's enabled by default in Hugo (since 0.60 I think).

This PR now makes two improvements:

 - use [a custom short code](https://gohugo.io/templates/shortcode-templates/) to simplify rendering the `<picture>` element (webp, then png, with png fallback if the browser doesn't support it).
 - drop the `unsafe` mode for rendering markdown :tada: